### PR TITLE
Fix typo in Device Onboarding documentation

### DIFF
--- a/hugo/content/3_how-tos/32_device-management/321_onboarding-a-device.md
+++ b/hugo/content/3_how-tos/32_device-management/321_onboarding-a-device.md
@@ -49,7 +49,7 @@ tags:
 * You can enable both the runtimes for a device at once.
 * You can enable/disable the runtime during the lifetime of a device. 
 * A device should always have one runtime enabled.
-For more information, see [Undertsand Runtimes](/5_deep-dives/51_managing-devices/511_device-runtime/).
+For more information, see [Understand Runtimes](/5_deep-dives/51_managing-devices/511_device-runtime/).
 
 ### Register a New Device
 


### PR DESCRIPTION
Corrected "Undertsand" to "Understand"



┆Issue is synchronized with this [Wrike task](https://www.wrike.com/open.htm?id=975892000)
